### PR TITLE
Adds the Hostname parameter to WsManListener to enable overriding the hostname in an HTTPS - Fixes #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Versions
 
+## 2.2.0.0
+
+- WSManListener:
+  - Added support for setting the Hostname of the listener will if the
+    subject of the certificate does not match the machine name - Fixes [Issue #11](https://github.com/PlagueHO/WSManDsc/issues/11).
+
 ## 2.1.0.0
 
 - Updated tests to meet Pester v4 standard.

--- a/Modules/WSManDsc/DSCResources/DSR_WSManListener/DSR_WSManListener.schema.mof
+++ b/Modules/WSManDsc/DSCResources/DSR_WSManListener/DSR_WSManListener.schema.mof
@@ -9,7 +9,7 @@ class DSR_WSManListener : OMI_BaseResource
     [Write, Description("The format used to match the certificate subject to use for an HTTPS WS-Man Listener if a thumbprint is not specified."), ValueMap{"Both","FQDNOnly","NameOnly"}, Values{"Both","FQDNOnly","NameOnly"}] String SubjectFormat;
     [Write, Description("Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man Listener if a thumbprint is not specified.")] Boolean MatchAlternate;
     [Write, Description("This is a Distinguished Name component that will be used to identify the certificate to use for the HTTPS WS-Man Listener if a thumbprint is not specified.")] String DN;
-    [Read, Description("The Host Name that an existing WS-Man Listener is bound to.")] String HostName;
+    [Write, Description("The host name that a HTTPS WS-Man Listener will be bound to. If not specified it will default to the computer name of the node.")] String Hostname;
     [Read, Description("Returns true if the existing WS-Man Listener is enabled.")] Boolean Enabled;
     [Read, Description("The URL Prefix of the existing WS-Man Listener.")] String URLPrefix;
     [Write, Description("The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.")] String CertificateThumbprint;

--- a/Modules/WSManDsc/Examples/Resources/WSManListener/4-WSManListener_HTTPS_WithThumbprint.ps1
+++ b/Modules/WSManDsc/Examples/Resources/WSManListener/4-WSManListener_HTTPS_WithThumbprint.ps1
@@ -1,0 +1,27 @@
+<#
+    .EXAMPLE
+        Create an HTTPS Listener using a LocalMachine certificate with a thumbprint
+        matching 'F2BE91E92AF040EF116E1CDC91D75C22F47D7BD6'. The host name in the
+        certificate must match the name of the host machine.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -Module WSManDsc
+
+    Node $NodeName
+    {
+        WSManListener HTTPS
+        {
+            Transport             = 'HTTPS'
+            Ensure                = 'Present'
+            CertificateThumbprint = 'F2BE91E92AF040EF116E1CDC91D75C22F47D7BD6'
+        } # End of WSManListener Resource
+    } # End of Node
+} # End of Configuration

--- a/Modules/WSManDsc/Examples/Resources/WSManListener/5-WSManListener_HTTPS_WithThumbprintAndHostname.ps1
+++ b/Modules/WSManDsc/Examples/Resources/WSManListener/5-WSManListener_HTTPS_WithThumbprintAndHostname.ps1
@@ -1,0 +1,30 @@
+<#
+    .EXAMPLE
+        Create an HTTPS Listener using a LocalMachine certificate with a thumbprint
+        matching 'F2BE91E92AF040EF116E1CDC91D75C22F47D7BD6'. If the subject in the
+        certificate does not match the name of the host then the Hostname parameter
+        must be specified. In this example the subject in the certificate is
+        'WsManListenerCert'.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -Module WSManDsc
+
+    Node $NodeName
+    {
+        WSManListener HTTPS
+        {
+            Transport             = 'HTTPS'
+            Ensure                = 'Present'
+            CertificateThumbprint = 'F2BE91E92AF040EF116E1CDC91D75C22F47D7BD6'
+            Hostname              = 'WsManListenerCert'
+        } # End of WSManListener Resource
+    } # End of Node
+} # End of Configuration

--- a/Modules/WSManDsc/WSManDsc.psd1
+++ b/Modules/WSManDsc/WSManDsc.psd1
@@ -4,7 +4,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '2.1.0.0'
+ModuleVersion = '2.2.0.0'
 
 # ID used to uniquely identify this module
 GUID = '15a87fbe-766b-4d2c-b856-645fd4a8d275'

--- a/Tests/Integration/DSR_WSManListener.Integration.Tests.ps1
+++ b/Tests/Integration/DSR_WSManListener.Integration.Tests.ps1
@@ -345,6 +345,159 @@ try
         }
     }
 
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_Add_HTTPS_ThumbprintHostname.config.ps1"
+    . $ConfigFile
+
+    # Create a certificate to use for the HTTPS listener
+    $CertFriendlyName = 'WS-Man HTTPS Integration Test Cert'
+
+    # Remove the certificate if it already exists
+    Get-ChildItem -Path 'Cert:\LocalMachine\My' |
+        Where-Object -Property FriendlyName -EQ $CertFriendlyName |
+        Remove-Item -Force
+
+    $Hostname = 'DummyHostName'
+    $Issuer = "CN=$Hostname"
+
+    # Create the certificate
+    if ([System.Environment]::OSVersion.Version.Major -ge 10)
+    {
+        # For Windows 10 or Windows Server 2016
+        $Certificate = New-SelfSignedCertificate `
+            -CertstoreLocation 'Cert:\LocalMachine\My' `
+            -Subject $Issuer `
+            -DnsName $Hostname `
+            -FriendlyName $CertFriendlyName
+    }
+    else
+    {
+        <#
+            New-SelfSignedCertificate in earlier OS versions will not make
+            a certificate that can be used for WS-Man. So we will use the
+            New-SelfSignedCertificateEx.ps1 script from the Script Center.
+            A request has been made to the author of this script to make it
+            available on PowerShellGallery.
+        #>
+        $ScriptFile = Join-Path -Path $ENV:Temp -ChildPath 'New-SelfSignedCertificateEx.ps1'
+        if (-not (Test-Path -Path $ScriptFile))
+        {
+            $ScriptZip = Join-Path -Path $ENV:Temp -ChildPath 'New-SelfSignedCertificateEx.zip'
+            Invoke-WebRequest `
+                -Uri 'https://gallery.technet.microsoft.com/scriptcenter/Self-signed-certificate-5920a7c6/file/101251/2/New-SelfSignedCertificateEx.zip' `
+                -OutFile $ScriptZip
+            Expand-Archive -Path $ScriptZip -DestinationPath $ENV:Temp
+            Remove-Item -Path $ScriptZip -Force
+        } # If
+        . $ScriptFile
+
+        $Certificate = New-SelfSignedCertificateEx `
+            -storeLocation 'LocalMachine' `
+            -Subject $Issuer `
+            -SubjectAlternativeName $($Hostname) `
+            -FriendlyName $CertFriendlyName `
+            -EnhancedKeyUsage 'Server Authentication'
+    } # if
+
+    Describe "$($script:DSCResourceName)_Integration_Add_HTTPS_Thumbprint_Hostname" {
+        # This is to pass to the Config
+        $configData = @{
+            AllNodes = @(
+                @{
+                    NodeName              = 'localhost'
+                    Transport             = 'HTTPS'
+                    Ensure                = 'Present'
+                    Port                  = 5986
+                    Address               = '*'
+                    CertificateThumbprint = $Certificate.Thumbprint
+                    Hostname              = $Hostname
+                }
+            )
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & "$($script:DSCResourceName)_Config_Add_HTTPS_Thumbprint_Hostname" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configData
+
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It 'Should have set the resource and all the parameters should match' {
+            # Get the Rule details
+            $Listeners = @(Get-WSManInstance `
+                    -ResourceURI winrm/config/Listener `
+                    -Enumerate)
+            if ($Listeners)
+            {
+                $NewListener = $Listeners.Where( {$_.Transport -eq $configData.AllNodes[0].Transport } )
+            }
+            $NewListener                    | Should -Not -Be $null
+            $NewListener.Port               | Should -Be $configData.AllNodes[0].Port
+            $NewListener.Address            | Should -Be $configData.AllNodes[0].Address
+        }
+    }
+
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_Remove_HTTPS.config.ps1"
+    . $ConfigFile
+
+    Describe "$($script:DSCResourceName)_Integration_Remove_HTTPS" {
+        $configData = @{
+            AllNodes = @(
+                @{
+                    NodeName  = 'localhost'
+                    Transport = 'HTTPS'
+                    Ensure    = 'Absent'
+                    Port      = 5986
+                    Address   = '*'
+                }
+            )
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & "$($script:DSCResourceName)_Config_Remove_HTTPS" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configData
+
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It 'Should have set the resource and all the parameters should match' {
+            # Get the Rule details
+            $Listeners = @(Get-WSManInstance `
+                    -ResourceURI winrm/config/Listener `
+                    -Enumerate)
+            if ($Listeners)
+            {
+                $NewListener = $Listeners.Where( {$_.Transport -eq $configData.AllNodes[0].Transport } )
+            }
+            $NewListener                    | Should -BeNullOrEmpty
+        }
+    }
+
     # Remove the certificate if it already exists
     Get-ChildItem -Path 'Cert:\LocalMachine\My' |
         Where-Object -Property FriendlyName -EQ $CertFriendlyName |

--- a/Tests/Integration/DSR_WSManListener_Add_HTTPS_ThumbprintHostname.config.ps1
+++ b/Tests/Integration/DSR_WSManListener_Add_HTTPS_ThumbprintHostname.config.ps1
@@ -1,0 +1,14 @@
+Configuration DSR_WSManListener_Config_Add_HTTPS_Thumbprint_Hostname {
+    Import-DscResource -ModuleName WSManDsc
+
+    node localhost {
+        WSManListener Integration_Test {
+            Transport             = $Node.Transport
+            Ensure                = $Node.Ensure
+            Port                  = $Node.Port
+            Address               = $Node.Address
+            CertificateThumbprint = $Node.CertificateThumbprint
+            Hostname              = $Node.Hostname
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 #---------------------------------#
 #      environment configuration  #
 #---------------------------------#
-version: 2.1.0.{build}
+version: 2.2.0.{build}
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR adds the Hostname parameter to WsManListener to enable overriding the hostname in an HTTPS listener if the certificate subject contains a different name.

**This Pull Request (PR) fixes the following issues:**
- Fixes #11

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/wsmandsc/12)
<!-- Reviewable:end -->
