### PR TITLE
Ensure all MOF parameters are returned in WSManListener - Fixes #21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   to root folder of repository and remove test harness - Fixes [Issue #19](https://github.com/PlagueHO/WSManDsc/issues/19).
 - Converted Examples to support format for publishing to PowerShell
   Gallery.
+- Change `Find-Certificate` in `WSManListener` to return entire certificate
+  instead of just thumbprint.
+- Fix `Get-TargetResource` in `WSManListener` to ensure all MOF parameters are
+  returned - Fixes [Issue #21](https://github.com/PlagueHO/WSManDsc/issues/21).
+- Minor style corrections to comment based help.
 
 ## 2.2.0.0
 

--- a/DSCResources/DSR_WSManListener/DSR_WSManListener.psm1
+++ b/DSCResources/DSR_WSManListener/DSR_WSManListener.psm1
@@ -16,13 +16,13 @@ $Default_HTTPS_Port = 5986
 
 <#
     .SYNOPSIS
-    Returns the current WS-Man Listener details.
+        Returns the current WS-Man Listener details.
 
     .PARAMETER Transport
-    The transport type of WS-Man Listener.
+        The transport type of WS-Man Listener.
 
     .PARAMETER Ensure
-    Specifies whether the WS-Man Listener should exist.
+        Specifies whether the WS-Man Listener should exist.
 #>
 function Get-TargetResource
 {
@@ -62,10 +62,19 @@ function Get-TargetResource
                     -f $Transport
             ) -join '' )
 
+        if ($listener.CertificateThumbprint)
+        {
+            $certificate = Find-Certificate -CertificateThumbprint $listener.CertificateThumbprint
+        }
+
         $returnValue += @{
             Ensure                = 'Present'
             Port                  = $listener.Port
             Address               = $listener.Address
+            Issuer                = $certificate.Issuer
+            SubjectFormat         = $null
+            MatchAlternate        = $null
+            DN                    = $null
             Hostname              = $listener.Hostname
             Enabled               = $listener.Enabled
             URLPrefix             = $listener.URLPrefix
@@ -82,7 +91,17 @@ function Get-TargetResource
             ) -join '' )
 
         $returnValue += @{
-            Ensure = 'Absent'
+            Ensure                = 'Absent'
+            Port                  = $null
+            Address               = $null
+            Issuer                = $null
+            SubjectFormat         = $null
+            MatchAlternate        = $null
+            DN                    = $null
+            Hostname              = $null
+            Enabled               = $null
+            URLPrefix             = $null
+            CertificateThumbprint = $null
         }
     } # if
 
@@ -94,35 +113,35 @@ function Get-TargetResource
     Sets the state of a WS-Man Listener.
 
     .PARAMETER Transport
-    The transport type of WS-Man Listener.
+        The transport type of WS-Man Listener.
 
     .PARAMETER Ensure
-    Specifies whether the WS-Man Listener should exist.
+        Specifies whether the WS-Man Listener should exist.
 
     .PARAMETER Port
-    The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
+        The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
 
     .PARAMETER Address
-    The Address that the WS-Man Listener will be bound to. The default is * (any address).
+        The Address that the WS-Man Listener will be bound to. The default is * (any address).
 
     .PARAMETER Issuer
-    The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
-    not specified.
+        The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
+        not specified.
 
     .PARAMETER SubjectFormat
-    The format used to match the certificate subject to use for an HTTPS WS-Man Listener
-    if a thumbprint is not specified.
+        The format used to match the certificate subject to use for an HTTPS WS-Man Listener
+        if a thumbprint is not specified.
 
     .PARAMETER MatchAlternate
-    Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
-    Listener if a thumbprint is not specified.
+        Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
+        Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-    This is a Distinguished Name component that will be used to identify the certificate to use
-    for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is a Distinguished Name component that will be used to identify the certificate to use
+        for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
-    The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
+        The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
 #>
 function Set-TargetResource
 {
@@ -228,7 +247,8 @@ function Set-TargetResource
             $null = $PSBoundParameters.Remove('Port')
             $null = $PSBoundParameters.Remove('Address')
 
-            [System.String] $thumbprint = Find-Certificate @PSBoundParameters
+            $certificate = Find-Certificate @PSBoundParameters
+            [System.String] $thumbprint = $certificate.thumbprint
 
             if ($thumbprint)
             {
@@ -317,38 +337,38 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests the state of a WS-Man Listener.
+        Tests the state of a WS-Man Listener.
 
     .PARAMETER Transport
-    The transport type of WS-Man Listener.
+        The transport type of WS-Man Listener.
 
     .PARAMETER Ensure
-    Specifies whether the WS-Man Listener should exist.
+        Specifies whether the WS-Man Listener should exist.
 
     .PARAMETER Port
-    The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
+        The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
 
     .PARAMETER Address
-    The Address that the WS-Man Listener will be bound to. The default is * (any address).
+        The Address that the WS-Man Listener will be bound to. The default is * (any address).
 
     .PARAMETER Issuer
-    The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
-    not specified.
+        The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
+        not specified.
 
     .PARAMETER SubjectFormat
-    The format used to match the certificate subject to use for an HTTPS WS-Man Listener
-    if a thumbprint is not specified.
+        The format used to match the certificate subject to use for an HTTPS WS-Man Listener
+        if a thumbprint is not specified.
 
     .PARAMETER MatchAlternate
-    Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
-    Listener if a thumbprint is not specified.
+        Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
+        Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-    This is a Distinguished Name component that will be used to identify the certificate to use
-    for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is a Distinguished Name component that will be used to identify the certificate to use
+        for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
-    The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
+        The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
 #>
 function Test-TargetResource
 {
@@ -487,10 +507,10 @@ function Test-TargetResource
 
 <#
     .SYNOPSIS
-    Looks up a WS-Man listener on the machine and returns the details.
+        Looks up a WS-Man listener on the machine and returns the details.
 
     .PARAMETER Transport
-    The transport type of WS-Man Listener.
+        The transport type of WS-Man Listener.
 #>
 function Get-Listener
 {
@@ -517,13 +537,13 @@ function Get-Listener
 
 <#
     .SYNOPSIS
-    Returns the port to use for the listener based on the transport and port.
+        Returns the port to use for the listener based on the transport and port.
 
     .PARAMETER Transport
-    The transport type of WS-Man Listener.
+        The transport type of WS-Man Listener.
 
     .PARAMETER Port
-    The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
+        The port the WS-Man Listener should use. Defaults to 5985 for HTTP and 5986 for HTTPS listeners.
 #>
 function Get-DefaultPort
 {
@@ -558,30 +578,31 @@ function Get-DefaultPort
 
 <#
     .SYNOPSIS
-    Finds the certificate to use for the HTTPS WS-Man Listener
+        Finds the certificate to use for the HTTPS WS-Man Listener
 
     .PARAMETER Issuer
-    The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
-    not specified.
+        The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is
+        not specified.
 
     .PARAMETER SubjectFormat
-    The format used to match the certificate subject to use for an HTTPS WS-Man Listener
-    if a thumbprint is not specified.
+        The format used to match the certificate subject to use for an HTTPS WS-Man Listener
+        if a thumbprint is not specified.
 
     .PARAMETER MatchAlternate
-    Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
-    Listener if a thumbprint is not specified.
+        Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man
+        Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-    This is a Distinguished Name component that will be used to identify the certificate to use
-    for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is a Distinguished Name component that will be used to identify the certificate to use
+        for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
-    The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
+        The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
 #>
 function Find-Certificate
 {
     [CmdletBinding()]
+    [OutputType([System.Security.Cryptography.X509Certificates.X509Certificate2])]
     param
     (
         [Parameter()]
@@ -614,126 +635,133 @@ function Find-Certificate
 
     if ($PSBoundParameters.ContainsKey('CertificateThumbprint'))
     {
-        $thumbprint = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                ($_.Thumbprint -eq $CertificateThumbprint)
-            } | Select-Object -First 1).Thumbprint
-
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
                 $($script:localizedData.FindCertificateByThumbprintMessage) `
                     -f $CertificateThumbprint
             ) -join '' )
 
-        return $thumbprint
-    } # if
-
-    # First try and find a certificate that is used to the FQDN of the machine
-    if ($SubjectFormat -in 'Both', 'FQDNOnly')
-    {
-        # Lookup the certificate using the FQDN of the machine
-        if ([System.String]::IsNullOrEmpty($Hostname))
-        {
-            $Hostname = [System.Net.Dns]::GetHostByName($ENV:computerName).Hostname
-        }
-        $Subject = "CN=$Hostname"
-
-        if ($PSBoundParameters.ContainsKey('DN'))
-        {
-            $Subject = "$Subject, $DN"
-        } # if
-
-        if ($MatchAlternate)
-        {
-            # Try and lookup the certificate using the subject and the alternate name
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.FindCertificateAlternateMessage) `
-                        -f $Issuer, $Subject, $Hostname
-                ) -join '' )
-
-            $thumbprint = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                    ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                            -contains 'Server Authentication') -and
-                    ($_.Issuer -eq $Issuer) -and
-                    ($Hostname -in $_.DNSNameList.Unicode) -and
-                    ($_.Subject -eq $Subject)
-                } | Select-Object -First 1).Thumbprint
-        }
-        else
-        {
-            # Try and lookup the certificate using the subject name
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.FindCertificateMessage) `
-                        -f $Issuer, $Subject
-                ) -join '' )
-
-            $thumbprint = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                    ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                            -contains 'Server Authentication') -and
-                    ($_.Issuer -eq $Issuer) -and
-                    ($_.Subject -eq $Subject)
-                } | Select-Object -First 1).Thumbprint
-        } # if
+        $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+                ($_.Thumbprint -eq $CertificateThumbprint)
+            } | Select-Object -First 1
     }
-
-    if (-not $thumbprint `
-            -and ($SubjectFormat -in 'Both', 'NameOnly'))
+    else
     {
-        # If could not find an FQDN cert, try for one issued to the computer name
-        [System.String] $Hostname = $ENV:ComputerName
-        [System.String] $Subject = "CN=$Hostname"
-
-        if ($PSBoundParameters.ContainsKey('DN'))
+        # First try and find a certificate that is used to the FQDN of the machine
+        if ($SubjectFormat -in 'Both', 'FQDNOnly')
         {
-            $Subject = "$Subject, $DN"
-        } # if
+            # Lookup the certificate using the FQDN of the machine
+            if ([System.String]::IsNullOrEmpty($Hostname))
+            {
+                $Hostname = [System.Net.Dns]::GetHostByName($ENV:computerName).Hostname
+            }
+            $Subject = "CN=$Hostname"
 
-        if ($MatchAlternate)
-        {
-            # Try and lookup the certificate using the subject and the alternate name
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.FindCertificateAlternateMessage) `
-                        -f $Issuer, $Subject, $Hostname
-                ) -join '' )
+            if ($PSBoundParameters.ContainsKey('DN'))
+            {
+                $Subject = "$Subject, $DN"
+            } # if
 
-            $thumbprint = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                    ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                            -contains 'Server Authentication') -and
-                    ($_.Issuer -eq $Issuer) -and
-                    ($Hostname -in $_.DNSNameList.Unicode) -and
-                    ($_.Subject -eq $Subject)
-                } | Select-Object -First 1).Thumbprint
+            if ($MatchAlternate)
+            {
+                # Try and lookup the certificate using the subject and the alternate name
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.FindCertificateAlternateMessage) `
+                            -f $Issuer, $Subject, $Hostname
+                    ) -join '' )
+
+                $certificate = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
+                                -contains 'Server Authentication') -and
+                        ($_.Issuer -eq $Issuer) -and
+                        ($Hostname -in $_.DNSNameList.Unicode) -and
+                        ($_.Subject -eq $Subject)
+                    } | Select-Object -First 1)
+            }
+            else
+            {
+                # Try and lookup the certificate using the subject name
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.FindCertificateMessage) `
+                            -f $Issuer, $Subject
+                    ) -join '' )
+
+                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
+                                -contains 'Server Authentication') -and
+                        ($_.Issuer -eq $Issuer) -and
+                        ($_.Subject -eq $Subject)
+                    } | Select-Object -First 1
+            } # if
         }
-        else
-        {
-            # Try and lookup the certificate using the subject name
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.FindCertificateMessage) `
-                        -f $Issuer, $Subject
-                ) -join '' )
 
-            $thumbprint = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                    ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                            -contains 'Server Authentication') -and
-                    ($_.Issuer -eq $Issuer) -and
-                    ($_.Subject -eq $Subject)
-                } | Select-Object -First 1).Thumbprint
+        if (-not $certificate `
+                -and ($SubjectFormat -in 'Both', 'NameOnly'))
+        {
+            # If could not find an FQDN cert, try for one issued to the computer name
+            [System.String] $Hostname = $ENV:ComputerName
+            [System.String] $Subject = "CN=$Hostname"
+
+            if ($PSBoundParameters.ContainsKey('DN'))
+            {
+                $Subject = "$Subject, $DN"
+            } # if
+
+            if ($MatchAlternate)
+            {
+                # Try and lookup the certificate using the subject and the alternate name
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.FindCertificateAlternateMessage) `
+                            -f $Issuer, $Subject, $Hostname
+                    ) -join '' )
+
+                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
+                                -contains 'Server Authentication') -and
+                        ($_.Issuer -eq $Issuer) -and
+                        ($Hostname -in $_.DNSNameList.Unicode) -and
+                        ($_.Subject -eq $Subject)
+                    } | Select-Object -First 1
+            }
+            else
+            {
+                # Try and lookup the certificate using the subject name
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.FindCertificateMessage) `
+                            -f $Issuer, $Subject
+                    ) -join '' )
+
+                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
+                                -contains 'Server Authentication') -and
+                        ($_.Issuer -eq $Issuer) -and
+                        ($_.Subject -eq $Subject)
+                    } | Select-Object -First 1
+            } # if
         } # if
     } # if
 
-    if (-not ([System.String]::IsNullOrEmpty($thumbprint)))
+    if ($certificate)
     {
         Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
                 $($script:localizedData.CertificateFoundMessage) `
-                    -f $thumbprint
+                    -f $certificate.thumbprint
+            ) -join '' )
+    }
+    else
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.CertificateNotFoundMessage) `
             ) -join '' )
     } # if
 
-    return $thumbprint
-} # Set-TargetResource
+    return $certificate
+} # Find-Certificate
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/DSR_WSManListener/en-us/DSR_WSManListener.strings.psd1
+++ b/DSCResources/DSR_WSManListener/en-us/DSR_WSManListener.strings.psd1
@@ -19,4 +19,5 @@ ConvertFrom-StringData @'
     FindCertificateMessage = Looking for machine server certificate with subject '{0}' issued by '{1}'.
     FindCertificateByThumbprintMessage = Looking for machine server certificate with thumbprint '{0}'.
     CertificateFoundMessage = Certificate found with thumbprint '{0}' to use for HTTPS Listener.
+    CertificateNotFoundMessage = Certificate not found.
 '@

--- a/DSCResources/DSR_WSManServiceConfig/DSR_WSManServiceConfig.psm1
+++ b/DSCResources/DSR_WSManServiceConfig/DSR_WSManServiceConfig.psm1
@@ -26,10 +26,10 @@ $script:parameterList = $resourceData.ParameterList
 
 <#
     .SYNOPSIS
-    Returns the WS-Man Service configuration.
+        Returns the WS-Man Service configuration.
 
     .PARAMETER IsSingleInstance
-    Specifies the resource is a single instance, the value must be 'Yes'
+        Specifies the resource is a single instance, the value must be 'Yes'
 #>
 function Get-TargetResource
 {
@@ -65,53 +65,53 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Sets the current WS-Man Service configuration.
+        Sets the current WS-Man Service configuration.
 
     .PARAMETER IsSingleInstance
-    Specifies the resource is a single instance, the value must be 'Yes'
+        Specifies the resource is a single instance, the value must be 'Yes'
 
     .PARAMETER RootSDDL
-    Specifies the security descriptor that controls remote access to the listener.
+        Specifies the security descriptor that controls remote access to the listener.
 
     .PARAMETER MaxConnections
-    Specifies the maximum number of active requests that the service can process simultaneously.
+        Specifies the maximum number of active requests that the service can process simultaneously.
 
     .PARAMETER MaxConcurrentOperationsPerUser
-    Specifies the maximum number of concurrent operations that any user can remotely open on the
-    same system.
+        Specifies the maximum number of concurrent operations that any user can remotely open on the
+        same system.
 
     .PARAMETER EnumerationTimeoutMS
-    Specifies the idle time-out in milliseconds between Pull messages.
+        Specifies the idle time-out in milliseconds between Pull messages.
 
     .PARAMETER MaxPacketRetrievalTimeSeconds
-    Specifies the maximum length of time, in seconds, the WinRM service takes to retrieve a packet.
+        Specifies the maximum length of time, in seconds, the WinRM service takes to retrieve a packet.
 
     .PARAMETER AllowUnencrypted
-    Allows the client computer to request unencrypted traffic.
+        Allows the client computer to request unencrypted traffic.
 
     .PARAMETER AuthBasic
-    Allows the WinRM service to use Basic authentication.
+        Allows the WinRM service to use Basic authentication.
 
     .PARAMETER AuthKerberos
-    Allows the WinRM service to use Kerberos authentication.
+        Allows the WinRM service to use Kerberos authentication.
 
     .PARAMETER AuthNegotiate
-    Allows the WinRM service to use Negotiate authentication.
+        Allows the WinRM service to use Negotiate authentication.
 
     .PARAMETER AuthCertificate
-    Allows the WinRM service to use client certificate-based authentication.
+        Allows the WinRM service to use client certificate-based authentication.
 
     .PARAMETER AuthCredSSP
-    Allows the WinRM service to use Credential Security Support Provider (CredSSP) authentication.
+        Allows the WinRM service to use Credential Security Support Provider (CredSSP) authentication.
 
     .PARAMETER AuthCbtHardeningLevel
-    Allows the client computer to request unencrypted traffic.
+        Allows the client computer to request unencrypted traffic.
 
     .PARAMETER EnableCompatibilityHttpListener
-    Specifies whether the compatibility HTTP listener is enabled.
+        Specifies whether the compatibility HTTP listener is enabled.
 
     .PARAMETER EnableCompatibilityHttpsListener
-    Specifies whether the compatibility HTTPS listener is enabled.
+        Specifies whether the compatibility HTTPS listener is enabled.
 #>
 function Set-TargetResource
 {
@@ -212,53 +212,53 @@ function Set-TargetResource
 
 <#
     .SYNOPSIS
-    Tests the current WS-Man Service configuration to see if any changes need to be made.
+        Tests the current WS-Man Service configuration to see if any changes need to be made.
 
     .PARAMETER IsSingleInstance
-    Specifies the resource is a single instance, the value must be 'Yes'
+        Specifies the resource is a single instance, the value must be 'Yes'
 
     .PARAMETER RootSDDL
-    Specifies the security descriptor that controls remote access to the listener.
+        Specifies the security descriptor that controls remote access to the listener.
 
     .PARAMETER MaxConnections
-    Specifies the maximum number of active requests that the service can process simultaneously.
+        Specifies the maximum number of active requests that the service can process simultaneously.
 
     .PARAMETER MaxConcurrentOperationsPerUser
-    Specifies the maximum number of concurrent operations that any user can remotely open on the
-    same system.
+        Specifies the maximum number of concurrent operations that any user can remotely open on the
+        same system.
 
     .PARAMETER EnumerationTimeoutMS
-    Specifies the idle time-out in milliseconds between Pull messages.
+        Specifies the idle time-out in milliseconds between Pull messages.
 
     .PARAMETER MaxPacketRetrievalTimeSeconds
-    Specifies the maximum length of time, in seconds, the WinRM service takes to retrieve a packet.
+        Specifies the maximum length of time, in seconds, the WinRM service takes to retrieve a packet.
 
     .PARAMETER AllowUnencrypted
-    Allows the client computer to request unencrypted traffic.
+        Allows the client computer to request unencrypted traffic.
 
     .PARAMETER AuthBasic
-    Allows the WinRM service to use Basic authentication.
+        Allows the WinRM service to use Basic authentication.
 
     .PARAMETER AuthKerberos
-    Allows the WinRM service to use Kerberos authentication.
+        Allows the WinRM service to use Kerberos authentication.
 
     .PARAMETER AuthNegotiate
-    Allows the WinRM service to use Negotiate authentication.
+        Allows the WinRM service to use Negotiate authentication.
 
     .PARAMETER AuthCertificate
-    Allows the WinRM service to use client certificate-based authentication.
+        Allows the WinRM service to use client certificate-based authentication.
 
     .PARAMETER AuthCredSSP
-    Allows the WinRM service to use Credential Security Support Provider (CredSSP) authentication.
+        Allows the WinRM service to use Credential Security Support Provider (CredSSP) authentication.
 
     .PARAMETER AuthCbtHardeningLevel
-    Allows the client computer to request unencrypted traffic.
+        Allows the client computer to request unencrypted traffic.
 
     .PARAMETER EnableCompatibilityHttpListener
-    Specifies whether the compatibility HTTP listener is enabled.
+        Specifies whether the compatibility HTTP listener is enabled.
 
     .PARAMETER EnableCompatibilityHttpsListener
-    Specifies whether the compatibility HTTPS listener is enabled.
+        Specifies whether the compatibility HTTPS listener is enabled.
 #>
 function Test-TargetResource
 {

--- a/Tests/Unit/DSR_WSManListener.Tests.ps1
+++ b/Tests/Unit/DSR_WSManListener.Tests.ps1
@@ -164,7 +164,7 @@ try
                 Mock -CommandName Remove-WSManInstance
                 Mock -CommandName New-WSManInstance
                 Mock -CommandName Find-Certificate -MockWith {
-                    return $mockCertificateThumbprint
+                    return $mockCertificate
                 }
 
                 It 'Should not throw error' {
@@ -264,7 +264,7 @@ try
                 Mock -CommandName Remove-WSManInstance
                 Mock -CommandName New-WSManInstance
                 Mock -CommandName Find-Certificate -MockWith {
-                    $mockCertificateThumbprint
+                    $mockCertificate
                 }
 
                 It 'Should not throw error' {
@@ -314,7 +314,7 @@ try
                 Mock -CommandName Remove-WSManInstance
                 Mock -CommandName New-WSManInstance
                 Mock -CommandName Find-Certificate -MockWith {
-                    $mockCertificateThumbprint
+                    $mockCertificate
                 }
 
                 It 'Should not throw error' {
@@ -481,13 +481,13 @@ try
                 Mock -CommandName Get-ChildItem
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -CertificateThumbprint $mockCertificateThumbprint `
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -BeNullOrEmpty
+                It 'Should return null' {
+                    $script:returnedCertificate | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected Mocks' {
@@ -501,13 +501,13 @@ try
                 }
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -CertificateThumbprint $mockCertificateThumbprint `
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -Be $mockCertificateThumbprint
+                It 'Should return expected certificate' {
+                    $script:returnedCertificate.Thumbprint | Should -Be $mockCertificateThumbprint
                 }
 
                 It 'Should call expected Mocks' {
@@ -519,7 +519,7 @@ try
                 Mock -CommandName Get-ChildItem
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
@@ -527,8 +527,8 @@ try
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -BeNullOrEmpty
+                It 'Should return null' {
+                    $script:returnedCertificate | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected Mocks' {
@@ -542,7 +542,7 @@ try
                 }
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
@@ -550,8 +550,8 @@ try
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return $mockCertificateThumbprint" {
-                    $script:ReturnedThumbprint | Should -Be $mockCertificateThumbprint
+                It 'Should return expected certificate' {
+                    $script:returnedCertificate.Thumbprint | Should -Be $mockCertificateThumbprint
                 }
 
                 It 'Should call expected Mocks' {
@@ -565,7 +565,7 @@ try
                 }
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
@@ -573,8 +573,8 @@ try
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -BeNullOrEmpty
+                It 'Should return null' {
+                    $script:returnedCertificate | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected Mocks' {
@@ -586,15 +586,15 @@ try
                 Mock -CommandName Get-ChildItem
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True  `
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -BeNullOrEmpty
+                It 'Should return null' {
+                    $script:returnedCertificate | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected Mocks' {
@@ -608,15 +608,15 @@ try
                 }
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True  `
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return empty" {
-                    $script:ReturnedThumbprint | Should -BeNullOrEmpty
+                It 'Should return null' {
+                    $script:returnedCertificate | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected Mocks' {
@@ -630,15 +630,15 @@ try
                 }
 
                 It 'Should not throw error' {
-                    { $script:ReturnedThumbprint = Find-Certificate `
+                    { $script:returnedCertificate = Find-Certificate `
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True  `
                         -Verbose } | Should -Not -Throw
                 }
 
-                It "Should return $mockCertificateThumbprint" {
-                    $script:ReturnedThumbprint | Should -Be $mockCertificateThumbprint
+                It 'Should return expected certificate' {
+                    $script:returnedCertificate.Thumbprint | Should -Be $mockCertificateThumbprint
                 }
 
                 It 'Should call expected Mocks' {


### PR DESCRIPTION
**Pull Request (PR) description**
This PR ensures that `Get-TargetResource` in WSManListener resource returns all the parameters in the MOF file.

It also corrects some style issues.

**This Pull Request (PR) fixes the following issues:**
- Fixes #21

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - would you mind reviewing this one for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/wsmandsc/22)
<!-- Reviewable:end -->
