### PR TITLE
Correct name of examples in configuration - Fixes #24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix `Get-TargetResource` in `WSManListener` to ensure all MOF parameters are
   returned - Fixes [Issue #21](https://github.com/PlagueHO/WSManDsc/issues/21).
 - Minor style corrections to comment based help.
+- Correct configuration names in Examples - fixes [Issue #24](https://github.com/PlagueHO/WSManDsc/issues/24).
 
 ## 2.2.0.0
 

--- a/Examples/Resources/WSManListener/1-WSManListener_HTTP_Config.ps1
+++ b/Examples/Resources/WSManListener/1-WSManListener_HTTP_Config.ps1
@@ -22,7 +22,7 @@
         This will create or enable an HTTP WS-Man Listener on port 5985.
         configuration Sample_WSManListener_HTTP
 #>
-Configuration Example
+Configuration WSManListener_HTTP_Config
 {
     Import-DscResource -Module WSManDsc
 

--- a/Examples/Resources/WSManListener/2-WSManListener_HTTPS_Config.ps1
+++ b/Examples/Resources/WSManListener/2-WSManListener_HTTPS_Config.ps1
@@ -23,7 +23,7 @@
         is installed and issued by 'CN=CONTOSO.COM Issuing CA, DC=CONTOSO, DC=COM'
         on port 5986.
 #>
-Configuration Example
+Configuration WSManListener_HTTPS_Config
 {
     Import-DscResource -Module WSManDsc
 

--- a/Examples/Resources/WSManListener/3-WSManListener_HTTPS_WithDN_Config.ps1
+++ b/Examples/Resources/WSManListener/3-WSManListener_HTTPS_WithDN_Config.ps1
@@ -23,7 +23,7 @@
         'O=Contoso Inc, S=Pennsylvania, C=US' that is installed and issued by
         'CN=CONTOSO.COM Issuing CA, DC=CONTOSO, DC=COM' on port 5986.
 #>
-Configuration Example
+Configuration WSManListener_HTTPS_WithDN_Config
 {
     Import-DscResource -Module WSManDsc
 

--- a/Examples/Resources/WSManListener/4-WSManListener_HTTPS_WithThumbprint_Config.ps1
+++ b/Examples/Resources/WSManListener/4-WSManListener_HTTPS_WithThumbprint_Config.ps1
@@ -23,7 +23,7 @@
         matching 'F2BE91E92AF040EF116E1CDC91D75C22F47D7BD6'. The host name in the
         certificate must match the name of the host machine.
 #>
-Configuration Example
+Configuration WSManListener_HTTPS_WithThumbprint_Config
 {
     Import-DscResource -Module WSManDsc
 

--- a/Examples/Resources/WSManListener/5-WSManListener_HTTPS_WithThumbprintAndHostname_Config.ps1
+++ b/Examples/Resources/WSManListener/5-WSManListener_HTTPS_WithThumbprintAndHostname_Config.ps1
@@ -25,7 +25,7 @@
         must be specified. In this example the subject in the certificate is
         'WsManListenerCert'.
 #>
-Configuration Example
+Configuration WSManListener_HTTPS_WithThumbprintAndHostname_Config
 {
     Import-DscResource -Module WSManDsc
 

--- a/Examples/Resources/WSManServiceConfig/1-WSManServiceConfig_Config.ps1
+++ b/Examples/Resources/WSManServiceConfig/1-WSManServiceConfig_Config.ps1
@@ -23,7 +23,7 @@
         maximum connections to 100, allow CredSSP (not recommended)
         and allow unecrypted WS-Man Sessions (not recommended).
 #>
-Configuration Example
+Configuration WSManServiceConfig_Config
 {
     Import-DscResource -Module WSManDsc
 


### PR DESCRIPTION
**Pull Request (PR) description**
This PR corrects the configuration names in the Example files to match the filename of the configuration, sans the numeric prefix.

**This Pull Request (PR) fixes the following issues:**
- Fixes #24

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind taking a look at this one when you can?